### PR TITLE
Little update for WoW BfA

### DIFF
--- a/_DevPad.lua
+++ b/_DevPad.lua
@@ -463,7 +463,7 @@ do
 			return;
 		end
 
-		PlaySound( "Glyph_MinorCreate" );
+		--PlaySound(SOUNDKIT.GLYPH_MINOR_CREATE);
 		local SafeName = Object._Name:gsub( "[|\r\n]", SafeNameReplacements );
 		self.Print( self.L.RECEIVE_MESSAGE_FORMAT:format( Author, SafeName ) );
 		if ( not ReopenPrinted and not ( self.GUI and self.GUI.List:IsVisible() ) ) then

--- a/_DevPad.toc
+++ b/_DevPad.toc
@@ -1,10 +1,10 @@
 # _DevPad has most recently been tested against:
-#   Version 7.3.5 (26365) (Release x64)
-#   Apr 3 2018
+#   Version 8.0.1 (27219) (Release x64)
+#   Aug 5 2018
 
 # The interface number can be learned with:
 #   /dump select( 4, GetBuildInfo() )
-## Interface:             70300
+## Interface:             80000
 ## Title:                 _|cffCCCC88DevPad|r
 ## Notes:                 Notepad for Lua scripts and mini-addons.
 ## Author:                Saiket, spiralofhope


### PR DESCRIPTION
1. TOC bump (80000)
2. _DevPad.lua: "Glyph_MinorCreate" sound is deleted from the game, and without patch it is causing lua error on new script received via addon messaging